### PR TITLE
log added in order, scrolls to bottom

### DIFF
--- a/biome-buddy/src/components/GameLog/GameLog.css
+++ b/biome-buddy/src/components/GameLog/GameLog.css
@@ -83,7 +83,7 @@
     overflow: auto;
     padding: 0.5rem;
     display: flex;
-    flex-direction: column-reverse;
+    flex-direction: column;
     gap: 0.5rem;
     flex: 1 1 auto;
 }

--- a/biome-buddy/src/components/GameLog/GameLog.jsx
+++ b/biome-buddy/src/components/GameLog/GameLog.jsx
@@ -18,10 +18,11 @@ export default function GameLog({ onCollapsedChange, darkMode }) {
     }, [])
 
     useEffect(() => {
-        // when new entry added, scroll to top of the list area
+        // when new entry added, scroll to bottom of the list area
         if (listRef.current) {
-            listRef.current.scrollTop = 0
+            listRef.current.scrollTop = listRef.current.scrollHeight
         }
+        console.log(entries);
     }, [entries])
 
     useEffect(() => {

--- a/biome-buddy/src/components/GameLog/GameLogSystem.jsx
+++ b/biome-buddy/src/components/GameLog/GameLogSystem.jsx
@@ -22,7 +22,7 @@ class GameLogSystem extends System {
         }
         // newest first
         this.entries.push(entry)
-        this.entries.sort((a, b) => b.timestamp - a.timestamp)
+        this.entries.sort((a, b) => a.timestamp - b.timestamp)
         this.emit()
         return entry
     }

--- a/biome-buddy/tests/Game.test.jsx
+++ b/biome-buddy/tests/Game.test.jsx
@@ -112,13 +112,13 @@ describe('Game integration and components', () => {
 		fireEvent.click(nextBtn)
 		const entriesA = gameLogSystem.getEntries()
 		expect(entriesA.length).toBeGreaterThanOrEqual(1)
-		expect(entriesA[0].message).toMatch(/seasons turn|struggles|breathes easier|plummeted|fragile|thrives in balance|Life goes on|growing faster/i)
+		expect(entriesA[entriesA.length - 1].message).toMatch(/seasons turn|struggles|breathes easier|plummeted|fragile|thrives in balance|Life goes on|growing faster/i)
 
 		// select Rabbit and advance -> logs a per-season message
 		const rabbit = screen.getByText('Rabbit')
 		fireEvent.click(rabbit)
 		const entriesB = gameLogSystem.getEntries()
-		expect(entriesB[0].message).toMatch(/flourishing|seasons turn|struggles|breathes easier|plummeted|fragile|thrives in balance|Life goes on|growing faster/i)
+		expect(entriesB[entriesA.length - 1].message).toMatch(/flourishing|seasons turn|struggles|breathes easier|plummeted|fragile|thrives in balance|Life goes on|growing faster/i)
 	})
 
 })


### PR DESCRIPTION
**Brief Description**: Game logs showed entries in the wrong color, and year/season ordering sometimes got mixed up

**High-level Description of Approach/Architecture**: Instead of column-reverse, logs are added in order and scroll to bottom of the container 

**To use the code**: `npm run dev` to see changes
